### PR TITLE
Fb newui datafinder

### DIFF
--- a/resources/web/dataFinder.css
+++ b/resources/web/dataFinder.css
@@ -47,6 +47,12 @@ TABLE.labkey-data-finder
 {
     clear:both;
 }
+
+.labkey-study-card-divider {
+    margin: 7px 0;
+    border-top: 1pt inset #AAAAAA;
+}
+
 DIV.labkey-study-card
 {
     background-color:#F8F8F8;
@@ -55,8 +61,8 @@ DIV.labkey-study-card
     margin: 5pt;
     float:left;
     position:relative;
-    width:160pt;
-    height:140pt;
+    width:172pt;
+    height:152pt;
     overflow-y:hidden;
 }
 
@@ -84,12 +90,12 @@ SPAN.labkey-study-search
 }
 
 /* search area */
-DIV.search-box
+DIV.df-search-box
 {
     float:left;
     padding:10pt;
 }
-INPUT.search-box
+INPUT.df-search-box
 {
     width:200pt;
 }
@@ -100,25 +106,25 @@ DIV.studyfinder-header
     padding-right:10pt;
 }
 
-DIV.search-message
+DIV.df-search-message
 {
     padding-left:10pt;
 }
 
-TD.selection-panel
+TD.df-selection-panel
 {
     vertical-align: text-top;
     width:220pt;
     height:100%;
 }
 
-TD.selection-panel > DIV
+TD.df-selection-panel > DIV
 {
     height:100%;
     overflow-y:auto;
 }
 
-DIV.help-links
+DIV.df-help-links
 {
     float:right;
     vertical-align: text-top;
@@ -126,79 +132,80 @@ DIV.help-links
     padding:3px 0px;
 }
 
-DIV.summary LI.member
+DIV.df-summary LI.df-member
 {
     clear:both;
     padding:2pt;
     margin:1px 0px 1px 0px;
     border:1px solid #ffffff;
-    height:14pt;
+    height:19.5pt;
     position:relative;
     width:100%;
 }
 
 /* facets */
 
-.clear-filter
+.df-clear-filter
 {
     float:right;
 }
 
-DIV.facet
+DIV.df-facet
 {
     max-width:200pt;
     border:solid 2pt rgb(220, 220, 220);
 }
 
+.labkey-study-card-summary,
 .active
 {
     cursor:pointer;
 }
-DIV.facet-header
+DIV.df-facet-header
 {
     padding:4pt;
     background-color: rgb(240, 240, 240);
 }
 
-DIV.facet-header .facet-caption
+DIV.df-facet-header .df-facet-caption
 {
     font-weight:400;
 }
 
-DIV.facet-header .labkey-filter-options
+DIV.df-facet-header .labkey-filter-options
 {
     font-size: 11px;
     padding: 3px 0px 0px 20px;
 }
 
-DIV.facet UL
+DIV.df-facet UL
 {
     list-style-type:none;
     padding-left:0;
     padding-right:5pt;
     margin:0;
 }
-DIV.facet LI.member
+DIV.df-facet LI.df-member
 {
     clear:both;
     cursor:pointer;
     padding:2pt;
     margin:1px 0px 1px 0px;
     border:1px solid #ffffff;
-    height:14pt;
+    height:19.5pt;
     position:relative;
     width:100%;
 }
-DIV.facet.collapsed LI.member
+DIV.df-facet.collapsed LI.df-member
 {
     display:none;
 }
-DIV.facet.collapsed .fa-plus-square
+DIV.df-facet.collapsed .fa-plus-square
 {
     float:left;
     display:inline;
 }
-DIV.facet.collapsed .fa-minus-square
+DIV.df-facet.collapsed .fa-minus-square
 {
     float:left;
     display:none;
@@ -213,19 +220,19 @@ DIV.expanded  .fa-minus-square
     float:left;
     display:inline;
 }
-DIV.facet.collapsed LI.member.selected-member
+DIV.df-facet.collapsed LI.df-member.df-selected-member
 {
     display:block;
 }
-DIV.facet LI.member:hover SPAN.bar
+DIV.df-facet LI.df-member:hover SPAN.df-bar
 {
     background-color:rgba(81, 158, 218, 0.2);
 }
-DIV.facet LI.empty-member
+DIV.df-facet LI.df-empty-member
 {
     color:#888888;
 }
-LI.member .member-indicator
+LI.df-member .df-member-indicator
 {
     position:relative;
     display:inline-block;
@@ -233,27 +240,27 @@ LI.member .member-indicator
     z-index:2;
     vertical-align: top;
 }
-.member-indicator.selected:after
+.df-member-indicator.selected:after
 {
     content:"\002713"
 }
-.member-indicator.selected:hover:after
+.df-member-indicator.selected:hover:after
 {
     content:"x";
 }
-.member-indicator.not-selected:after
+.df-member-indicator.not-selected:after
 {
     content:"\0025FB"
 }
-.member-indicator.not-selected:hover:after
+.df-member-indicator.not-selected:hover:after
 {
     content:"\002713"
 }
-.member-indicator.not-selected.none-selected:after
+.df-member-indicator.not-selected.df-none-selected:after
 {
     content:"\002713"; color:lightgray;
 }
-LI.member .member-name
+LI.df-member .df-member-name
 {
     display:inline-block;
     position:relative;
@@ -263,19 +270,19 @@ LI.member .member-name
     white-space: nowrap;
     z-index:2;
 }
-LI.member .member-count
+LI.df-member .df-member-count
 {
     position:relative;
     float:right;
     z-index:2;
 }
 
-LI.member SPAN.bar-selected
+LI.df-member SPAN.df-bar-selected
 {
     background-color:rgba(81, 158, 218, 0.2);
 }
 
-LI.member .bar
+LI.df-member .df-bar
 {
     height:14pt;
     background-color:#DEDEDE;
@@ -307,30 +314,30 @@ DIV.labkey-filter-popup
 }
 
 /* menus */
-.nav
+.df-nav
 {
     margin: 0;
     padding-left: 0;;
     list-style: none;
 }
 
-ul.nav
+ul.df-nav
 {
     display:block;
 }
 
-.navbar-nav > li
+.df-navbar-nav > li
 {
     float: left;
 }
 
-.navbar-nav
+.df-navbar-nav
 {
     float: left;
     margin: 0;
 }
 
-.navbar-nav > li > .labkey-dropdown-menu
+.df-navbar-nav > li > .labkey-dropdown-menu
 {
     margin-top : 0;
 }
@@ -407,33 +414,38 @@ ul.nav
     -webkit-padding-start: 0px
 }
 
-#manageMenu > a {
+#df-manageMenu > a {
     color:black;
     padding-right: 5px;
 }
 
-.menu-item-link {
+.df-menu-item-link {
     line-height: 22px;
     display: inline-block;
     padding: 0 8px 0 8px;
 }
 
+.labkey-study-detail {
+    border-color: #F8F8F8;
+    background-color: #F8F8F8;
+    padding: 0 20px 20px 20px;
+    box-shadow: 0 1px 1px rgba(0,0,0,0.15), -1px 0 0 rgba(0,0,0,0.06), 1px 0 0 rgba(0,0,0,0.06), 0 1px 0 rgba(0,0,0,0.12);
+}
+
 .labkey-study-detail .x4-window-header {
     background-color: #F8F8F8;
-    padding: 0;
     box-shadow: #F8F8F8 0 0 0 0;
 }
 
-.labkey-study-detail {
-    border-color: #F8F8F8;
-    padding: 0;
+.labkey-study-detail .study-title {
+    font-family: 'Roboto-Bold', 'Arial-Bold', 'Helvetica-Bold', sans-serif;
+    font-weight: bold;
 }
 
 div.study-demographics {
     background-color: white;
     padding: 10px 20px 20px 20px;
     margin-top: 10px;
-    box-shadow: 0 1px 1px rgba(0,0,0,0.15), -1px 0 0 rgba(0,0,0,0.06), 1px 0 0 rgba(0,0,0,0.06), 0 1px 0 rgba(0,0,0,0.12);
 }
 
 div.study-demographics h2 {
@@ -456,13 +468,13 @@ div.study-demographics h3 {
     border-bottom: 1px solid darkgray;
 }
 
-#demographics-content .detail {
+#demographics-content .df-detail {
     font-size: 15px;
     padding-left: 30px;
     padding-bottom: 5px;
 }
 
-#demographics-content .detail div {
+#demographics-content .df-detail div {
     font-size: 15px;
 }
 
@@ -475,14 +487,14 @@ div.study-demographics h3 {
     padding: 3px;
 }
 
-#demographics-content div.label, a.label {
+#demographics-content div.df-label, a.df-label {
     font-size: 12px;
     color: #a9a9a9;
     vertical-align: text-top;
 }
 
 
-#assays-content .detail div {
+#assays-content .df-detail div {
     font-size: 15px;
     padding: 3px;
 }

--- a/src/org/labkey/immport/view/dataFinder.jsp
+++ b/src/org/labkey/immport/view/dataFinder.jsp
@@ -99,19 +99,19 @@
                         <span ng-if="isGroupNotFound()" class="fa fa-exclamation-circle" data-qtip="{{currentGroup.groupNotFound}}"></span>
                     </div>
 
-                    <div class="navbar navbar-default ">
-                        <ul class="nav navbar-nav">
-                            <li id="manageMenu" class="labkey-dropdown" ng-mouseover="openMenu($event, true)">
+                    <div class="df-navbar df-navbar-default ">
+                        <ul class="df-nav df-navbar-nav">
+                            <li id="df-manageMenu" class="labkey-dropdown" ng-mouseover="openMenu($event, true)">
                                 <a href="#"><i class="fa fa-cog"></i></a>
                                 <ul class="labkey-dropdown-menu" ng-show="!isGuest">
-                                    <li class="x4-menu-item-text"><a class="menu-item-link" href="<%=h(new ActionURL("study", "manageParticipantCategories", getContainer()))%>">Manage Groups</a></li>
+                                    <li class="x4-menu-item-text"><a class="df-menu-item-link" href="<%=h(new ActionURL("study", "manageParticipantCategories", getContainer()))%>">Manage Groups</a></li>
                                 </ul>
                             </li>
                             <li id="loadMenu" class="labkey-dropdown" >
                                 <a ng-class="{'labkey-text-link' : loadedStudiesShown(), 'labkey-disabled-text-link': !loadedStudiesShown()} " class="no-arrow" style="margin-right: 0.8em" href="#" ng-mouseover="openMenu($event, false)">Load <i class="fa fa-caret-down"></i></a>
                                 <ul class="labkey-dropdown-menu" ng-show="loadedStudiesShown() && groupsAvailable()" >
                                     <li class="x4-menu-item-text" ng-repeat="group in groupList">
-                                        <a class="menu-item-link" ng-click="applySubjectGroupFilter(group, $event)">{{group.label}}</a>
+                                        <a class="df-menu-item-link" ng-click="applySubjectGroupFilter(group, $event)">{{group.label}}</a>
                                     </li>
                                 </ul>
                             </li>
@@ -119,12 +119,12 @@
                                 <a ng-class="{'labkey-text-link' : loadedStudiesShown(), 'labkey-disabled-text-link': !loadedStudiesShown()} " class="no-arrow" style="margin-right: 0.8em" href="#" ng-mouseover="openMenu($event, false)" ng-mouseleave="closeMenu($event)">Save <i class="fa fa-caret-down"></i> </a>
                                 <ul class="labkey-dropdown-menu" ng-if="!isGuest && loadedStudiesShown()">
                                     <li class="x4-menu-item-text" ng-repeat="opt in saveOptions" ng-class="{'inactive' : !opt.isActive}">
-                                        <a class="menu-item-link" ng-class="{'inactive' : !opt.isActive}" ng-click="saveSubjectGroup(opt.id, false, $event)">{{opt.label}}</a>
+                                        <a class="df-menu-item-link" ng-class="{'inactive' : !opt.isActive}" ng-click="saveSubjectGroup(opt.id, false, $event)">{{opt.label}}</a>
                                     </li>
                                 </ul>
                                 <ul class="labkey-dropdown-menu" ng-if="isGuest">
                                     <li class="x4-menu-item-text">
-                                        <span class="menu-item-link">You must be logged in to save a group.</span>
+                                        <span class="df-menu-item-link">You must be logged in to save a group.</span>
                                     </li>
                                 </ul>
                             </li>
@@ -132,7 +132,7 @@
                                 <a ng-class="{'labkey-text-link' : !isGuest && loadedStudiesShown(), 'labkey-disabled-text-link': isGuest || !loadedStudiesShown()} " class="no-arrow" href="#" ng-click="sendSubjectGroup($event)">Send</a>
                             </li>
                         </ul>
-                        <span class="clear-filter active" ng-show="hasFilters()" ng-click="clearAllClick();">[clear all]</span>
+                        <span class="df-clear-filter active" ng-show="hasFilters()" ng-click="clearAllClick();">[clear all]</span>
                     </div>
 
                 </div>
@@ -140,9 +140,9 @@
             </td>
             <td>
                 <div class="studyfinder-header">
-                    <span class="search-box">
+                    <span class="df-search-box">
                         <i class="fa fa-search"></i>&nbsp;
-                        <input placeholder="Studies" id="searchTerms" name="q" class="search-box"  ng-model="searchTerms" ng-change="onSearchTermsChanged()" type="search">
+                        <input placeholder="Studies" id="searchTerms" name="q" class="df-search-box"  ng-model="searchTerms" ng-change="onSearchTermsChanged()" type="search">
                     </span>
                     <span class="labkey-study-search">
                         <select ng-model="studySubset" name="studySubsetSelect" ng-change="onStudySubsetChanged()">
@@ -151,10 +151,10 @@
                     </span>
                     <span class="study-search">{{searchMessage}}</span>
                 </div>
-		<div class="search-message">
+		<div class="df-search-message">
                     <span id="message" class="labkey-filter-message" ng-if="!loadedStudiesShown()">No data are available for participants since you are viewing unloaded studies.</span>
 		</div>
-		<div class="help-links">
+		<div class="df-help-links">
                 <%=textLink("quick help", "#", "start_tutorial()", "showTutorial")%>
                 <%=textLink("Export Study Datasets", ImmPortController.ExportStudyDatasetsAction.class)%>
                 <%
@@ -170,19 +170,19 @@
             </td>
         </tr>
         <tr>
-            <td class="selection-panel">
+            <td class="df-selection-panel">
                 <div id="selectionPanel">
                     <div>
-                        <div class="facet" id="summaryArea" >
-                            <div class="facet-header"><span class="facet-caption">Summary</span></div>
+                        <div class="df-facet" id="summaryArea" >
+                            <div class="df-facet-header"><span class="df-facet-caption">Summary</span></div>
                             <ul>
-                                <li class="member" style="cursor: default">
-                                    <span class="member-name">Studies</span>
-                                    <span class="member-count">{{dimStudy.summaryCount}}</span>
+                                <li class="df-member" style="cursor: default">
+                                    <span class="df-member-name">Studies</span>
+                                    <span class="df-member-count">{{dimStudy.summaryCount}}</span>
                                 </li>
-                                <li class="member" style="cursor: default">
-                                    <span class="member-name">Participants</span>
-                                    <span class="member-count">{{formatNumber(dimSubject.allMemberCount||0)}}</span>
+                                <li class="df-member" style="cursor: default">
+                                    <span class="df-member-name">Participants</span>
+                                    <span class="df-member-count">{{formatNumber(dimSubject.allMemberCount||0)}}</span>
                                 </li>
                             </ul>
                         </div>
@@ -208,7 +208,7 @@
 <div id="filterPopup" class="labkey-filter-popup" style="top:{{filterChoice.y}}px; left:{{filterChoice.x}}px;" ng-if="filterChoice.show" ng-mouseleave="filterChoice.show = false">
     <ul class="labkey-dropdown-menu" ng-if="filterChoice.options.length > 1">
         <li class="x4-menu-item-text" ng-repeat="option in filterChoice.options">
-            <a class="menu-item-link" ng-click="setFilterType(filterChoice.dimName,option.type)">{{option.caption}}</a>
+            <a class="df-menu-item-link" ng-click="setFilterType(filterChoice.dimName,option.type)">{{option.caption}}</a>
         </li>
     </ul>
 </div>
@@ -233,30 +233,30 @@
 
 
 <script type="text/ng-template" id="/facet.html">
-    <div id="group_{{dim.name}}" class="facet"
+    <div id="group_{{dim.name}}" class="df-facet"
          ng-class="{expanded:dim.expanded, collapsed:!dim.expanded, noneSelected:(0==dim.filters.length)}">
-        <div class="facet-header">
-            <div class="facet-caption active" ng-click="dim.expanded=!dim.expanded" ng-mouseover="filterChoice.show = false">
+        <div class="df-facet-header">
+            <div class="df-facet-caption active" ng-click="dim.expanded=!dim.expanded" ng-mouseover="filterChoice.show = false">
                 <i class="fa fa-plus-square"></i>
                 <i class="fa fa-minus-square"></i>
                 &nbsp;
                 <span>{{dim.caption || dim.name}}</span>
-                <span ng-if="dim.filters.length" class="clear-filter active" ng-click="selectMember(dim.name,null,$event);">[clear]</span>
+                <span ng-if="dim.filters.length" class="df-clear-filter active" ng-click="selectMember(dim.name,null,$event);">[clear]</span>
             </div>
             <div class="labkey-filter-options" ng-if="dim.filters.length > 1 && dim.filterOptions.length > 0" >
                 <a ng-click="displayFilterChoice(dim.name, $event)" ng-mouseover="displayFilterChoice(dim.name,$event);"  class="x4-menu-item-text" ng-class="{inactive: dim.filterOptions.length < 2}" href="#">{{dim.filterCaption}} <i ng-if="dim.filterOptions.length > 1" class="fa fa-caret-down"></i></a>
             </div>
         </div>
         <ul>
-            <li ng-repeat="member in dim.members | filter:isMemberVisible" id="m_{{dim.name}}_{{member.uniqueName}}" style="position:relative;" class="member"
-                 ng-class="{'selected-member':member.selected, 'empty-member':(!member.selected && member.count == 0)}"
+            <li ng-repeat="member in dim.members | filter:isMemberVisible" id="m_{{dim.name}}_{{member.uniqueName}}" style="position:relative;" class="df-member"
+                 ng-class="{'df-selected-member':member.selected, 'df-empty-member':(!member.selected && member.count == 0)}"
                  ng-click="selectMember(dim.name,member,$event)">
-                <span class="active member-indicator" ng-class="{selected:member.selected, 'none-selected':!dim.filters.length, 'not-selected':!member.selected}" ng-click="toggleMember(dim.name,member,$event)">
+                <span class="active df-member-indicator" ng-class="{selected:member.selected, 'df-none-selected':!dim.filters.length, 'not-selected':!member.selected}" ng-click="toggleMember(dim.name,member,$event)">
                 </span>
-                <span class="member-name">{{member.name}}</span>
+                <span class="df-member-name">{{member.name}}</span>
                 &nbsp;
-                <span class="member-count">{{formatNumber(member.count)}}</span>
-                <span ng-class="{'bar-selected':member.selected}" class="bar" ng-show="member.count" style="width:{{member.percent}}%;"></span>
+                <span class="df-member-count">{{formatNumber(member.count)}}</span>
+                <span ng-class="{'df-bar-selected':member.selected}" class="df-bar" ng-show="member.count" style="width:{{member.percent}}%;"></span>
             </li>
         </ul>
     </div>

--- a/test/src/org/labkey/test/pages/immport/DataFinderPage.java
+++ b/test/src/org/labkey/test/pages/immport/DataFinderPage.java
@@ -301,7 +301,7 @@ public class DataFinderPage extends LabKeyPage
         public static final Locator.CssLocator saveMenu = Locator.css("#saveMenu");
         public static final Locator.CssLocator loadMenu = Locator.css("#loadMenu");
         public static final Locator.CssLocator sendMenu = Locator.css("#sendMenu");
-        public static final Locator.IdLocator manageMenu = Locator.id("manageMenu");
+        public static final Locator.IdLocator manageMenu = Locator.id("df-manageMenu");
         public static final Locator.CssLocator savedGroups = loadMenu.append(" ul.labkey-dropdown-menu-active");
         public static final Locator.XPathLocator save = Locator.xpath("//li[contains(@ng-repeat, 'saveOptions')][not(contains(@class, 'inactive'))]").append(Locator.linkWithText("Save"));
         public static final Locator.XPathLocator saveAs = Locator.xpath("//li[contains(@ng-repeat, 'saveOptions')][not(contains(@class, 'inactive'))]").append(Locator.linkWithText("Save As"));
@@ -418,8 +418,8 @@ public class DataFinderPage extends LabKeyPage
 
         private class Elements
         {
-            public Locator.CssLocator activeOption = Locator.css(".menu-item-link:not(.inactive)");
-            public Locator.CssLocator inactiveOption = Locator.css(".menu-item-link.inactive");
+            public Locator.CssLocator activeOption = Locator.css(".df-menu-item-link:not(.inactive)");
+            public Locator.CssLocator inactiveOption = Locator.css(".df-menu-item-link.inactive");
         }
     }
 

--- a/test/src/org/labkey/test/pages/immport/DataFinderPage.java
+++ b/test/src/org/labkey/test/pages/immport/DataFinderPage.java
@@ -289,11 +289,11 @@ public class DataFinderPage extends LabKeyPage
         public static final Locator.CssLocator studySearchInput = studyFinder.append(Locator.css("#searchTerms"));
         public static final Locator.NameLocator studySubsetChooser = Locator.name("studySubsetSelect");
         public static final Locator.CssLocator studyCard = studyFinder.append(Locator.css(".labkey-study-card"));
-        public static final Locator.CssLocator selectionPanel = studyFinder.append(Locator.css(".selection-panel"));
+        public static final Locator.CssLocator selectionPanel = studyFinder.append(Locator.css(".df-selection-panel"));
         public static final Locator.CssLocator facetPanel = selectionPanel.append(Locator.css("#facetPanel"));
-        public static final Locator.CssLocator facet = facetPanel.append(" .facet");
+        public static final Locator.CssLocator facet = facetPanel.append(" .df-facet");
         public static final Locator.CssLocator summaryArea = selectionPanel.append(Locator.css("#summaryArea"));
-        public static final Locator.CssLocator selection = facetPanel.append(Locator.css(" .selected-member"));
+        public static final Locator.CssLocator selection = facetPanel.append(Locator.css(" .df-selected-member"));
         public static final Locator.CssLocator clearAll = Locator.css("span[ng-click='clearAllFilters(true);']");
         public static final Locator.CssLocator clearAllFilters = Locator.css("span[ng-click='clearAllClick();']");
         public static final Locator.CssLocator groupLabel = Locator.css(".labkey-group-label");
@@ -575,17 +575,17 @@ public class DataFinderPage extends LabKeyPage
 
         private class Elements
         {
-            public Locator.CssLocator facetCaption = Locator.css(".facet-caption");
-            public Locator.CssLocator dimension = Locator.css(".facet-caption > span");
-            public Locator.CssLocator member = Locator.css(".member");
-            public Locator.CssLocator memberName = Locator.css(".member-name");
-            public Locator.CssLocator memberCount = Locator.css(".member-count");
-            public Locator.CssLocator selectedMemberCheck = Locator.css(".member .member-indicator.selected");
-            public Locator.CssLocator emptyMemberName = Locator.css(".ng-scope.empty-member .member-name");
-            public Locator.CssLocator nonEmptyMemberName = Locator.css(".ng-scope.member:not(.empty-member) .member-name");
-            public Locator.CssLocator nonEmptyNonSelectedMemberName = Locator.css(".ng-scope.member:not(.empty-member):not(.selected-member) .member-name");
-            public Locator.CssLocator selectedMemberName = Locator.css(".ng-scope.selected-member .member-name");
-            public Locator.CssLocator clearFilters = Locator.css(".clear-filter");
+            public Locator.CssLocator facetCaption = Locator.css(".df-facet-caption");
+            public Locator.CssLocator dimension = Locator.css(".df-facet-caption > span");
+            public Locator.CssLocator member = Locator.css(".df-member");
+            public Locator.CssLocator memberName = Locator.css(".df-member-name");
+            public Locator.CssLocator memberCount = Locator.css(".df-member-count");
+            public Locator.CssLocator selectedMemberCheck = Locator.css(".df-member .df-member-indicator.selected");
+            public Locator.CssLocator emptyMemberName = Locator.css(".ng-scope.df-empty-member .df-member-name");
+            public Locator.CssLocator nonEmptyMemberName = Locator.css(".ng-scope.df-member:not(.df-empty-member) .df-member-name");
+            public Locator.CssLocator nonEmptyNonSelectedMemberName = Locator.css(".ng-scope.df-member:not(.df-empty-member):not(.df-selected-member) .df-member-name");
+            public Locator.CssLocator selectedMemberName = Locator.css(".ng-scope.df-selected-member .df-member-name");
+            public Locator.CssLocator clearFilters = Locator.css(".df-clear-filter");
         }
     }
 
@@ -687,8 +687,8 @@ public class DataFinderPage extends LabKeyPage
 
         private class Elements
         {
-            public Locator memberName = Locator.css(".member-name");
-            public Locator memberCount = Locator.css(".member-count");
+            public Locator memberName = Locator.css(".df-member-name");
+            public Locator memberCount = Locator.css(".df-member-count");
         }
     }
 }


### PR DESCRIPTION
The current data finder webpart uses many css classes with very generic names, so some of them overlap now with class names from bootstrap or other core LabKey UI pieces, so this pull request prefixes many of the data frame classes with "df-".